### PR TITLE
Chore: enable azure blob overwrite

### DIFF
--- a/grafana_backup/azure_storage_upload.py
+++ b/grafana_backup/azure_storage_upload.py
@@ -15,7 +15,7 @@ def main(args, settings):
         blob_service_client = BlobServiceClient.from_connection_string(azure_storage_connection_string)
         container_client = blob_service_client.get_blob_client(container=azure_storage_container_name, blob=azure_file_name)
         with open(archive_file, 'rb') as data:
-            container_client.upload_blob(data)
+            container_client.upload_blob(data, overwrite=True)
         print("Upload to Azure Storage was successful")
     except FileNotFoundError:  # noqa: F821
         print("The file was not found")


### PR DESCRIPTION
issue:
```created archive at: grafana/latest.tar.gz
Upload archives to Azure Storage:
The specified blob already exists.
RequestId:93153cda-f01e-003b-7ebf-fc3045000000
Time:2025-07-24T17:20:08.1355152Z
ErrorCode:BlobAlreadyExists
Content: <?xml version="1.0" encoding="utf-8"?><Error><Code>BlobAlreadyExists</Code><Message>The specified blob already exists.
RequestId:93153cda-f01e-003b-7ebf-fc3045000000
Time:2025-07-24T17:20:08.1355152Z</Message></Error>```

